### PR TITLE
Fix for 32bit architecture

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "arch": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/arch/-/arch-2.1.1.tgz",
+      "integrity": "sha512-BLM56aPo9vLLFVa8+/+pJLnrZ7QGGTVHWsCwieAWT9o9K8UeGaQbzZbGoabWLOo2ksBCztoXdqBZBplqLDDCSg=="
+    },
     "bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/pfirpfel/node-exclusive-keyboard#readme",
   "dependencies": {
+    "arch": "^2.1.1",
     "bindings": "^1.5.0",
     "nan": "^2.14.0"
   }


### PR DESCRIPTION
This library makes assumptions about the input event, which are only fulfilled on 64bit architectures.
The part of the event containts a timestamp, which has a length of two `long`-types.
On 64bit platforms it's 16bytes, on 32bit only 8. That's why on 32bit systems nothing gets captured.
32bit is still common for maker-boards like the Raspberry PI .

This PR adds a check for 64bit architeture using the `arch`-package (because `os.arch()` returns e.g `darwin` on osx which can be 64bit etc...). Than all offset values are calculated depending on the current architecture.